### PR TITLE
Implement index returns filenames instead of read_ids for format_chromap

### DIFF
--- a/seqspec/Read.py
+++ b/seqspec/Read.py
@@ -90,6 +90,11 @@ class Read(yaml.YAMLObject):
                     return self
         return None
 
+    def get_filenames(self):
+        """Returns the filenames attached to this Read object
+        """
+        return [getattr(f, "filename", None) for f in getattr(self, "files", [])]
+
 
 class ReadCoordinate:
     def __init__(self, read: Read, rcv: List[RegionCoordinate]) -> None:

--- a/seqspec/seqspec_index.py
+++ b/seqspec/seqspec_index.py
@@ -171,7 +171,7 @@ def run_index(
     else:
         print(x)
 
-    return
+    return x
 
 
 def index(

--- a/seqspec/seqspec_index.py
+++ b/seqspec/seqspec_index.py
@@ -408,10 +408,10 @@ def stable_deduplicate_fqs(fqs):
     return deduplicated_fqs
 
 
-    bc_fqs = []
 def format_chromap(spec, indices, subregion_type=None):
+    bc_read_ids = []
     bc_str = []
-    gdna_fqs = []
+    gdna_read_ids = []
     gdna_str = []
     for idx, region in enumerate(indices):
         rg_strand = region.pop("strand")
@@ -419,21 +419,24 @@ def format_chromap(spec, indices, subregion_type=None):
         for rgn, cuts in region.items():
             for cut in cuts:
                 if cut.region_type.upper() == "BARCODE":
-                    bc_fqs.append(rgn)
+                    bc_read_ids.append(rgn)
                     bc_str.append(f"bc:{cut.start}:{cut.stop-1}{strand}")
                     pass
                 elif cut.region_type.upper() == "GDNA":
-                    gdna_fqs.append(rgn)
+                    gdna_read_ids.append(rgn)
                     gdna_str.append(f"{cut.start}:{cut.stop-1}")
-    if len(set(bc_fqs)) > 1:
+    if len(set(bc_read_ids)) > 1:
         raise Exception("chromap only supports barcodes from one fastq")
-    if len(set(gdna_fqs)) > 2:
+    if len(set(gdna_read_ids)) > 2:
         raise Exception("chromap only supports genomic dna from two fastqs")
 
-    barcode_fq = bc_fqs[0]
-    deduplicated_gdna_fqs = stable_deduplicate_fqs(gdna_fqs)
-    read1_fq = deduplicated_gdna_fqs[0]
-    read2_fq = deduplicated_gdna_fqs[1]
+    barcode_read = spec.get_read(bc_read_ids[0])
+    barcode_fq = ",".join(barcode_read.get_filenames())
+    deduplicated_gdna_read_ids = stable_deduplicate_fqs(gdna_read_ids)
+    read1_read = spec.get_read(deduplicated_gdna_read_ids[0])
+    read2_read = spec.get_read(deduplicated_gdna_read_ids[1])
+    read1_fq = ",".join(read1_read.get_filenames())
+    read2_fq = ",".join(read2_read.get_filenames())
     read_str = ",".join([f"r{idx}:{ele}" for idx, ele in enumerate(gdna_str, 1)])
     bc_str = ",".join(bc_str)
 

--- a/seqspec/seqspec_index.py
+++ b/seqspec/seqspec_index.py
@@ -210,7 +210,7 @@ def index(
     else:
         indices = GET_INDICES_BY_IDS[idtype](spec, modality, ids)
 
-    return FORMAT[fmt](indices, subregion_type)
+    return FORMAT[fmt](spec, indices, subregion_type)
 
 
 def get_index_by_files(spec, modality):
@@ -283,7 +283,7 @@ def get_index_by_primer(
     return {read_id: new_rcs, "strand": rdc.read.strand}
 
 
-def format_kallisto_bus(indices, subregion_type=None):
+def format_kallisto_bus(spec, indices, subregion_type=None):
     bcs = []
     umi = []
     feature = []
@@ -313,7 +313,7 @@ def format_kallisto_bus(indices, subregion_type=None):
 
 # this one should only return one string
 # TODO: return to this
-def format_seqkit_subseq(indices, subregion_type=None):
+def format_seqkit_subseq(spec, indices, subregion_type=None):
     # The x string format is start:stop (1-indexed)
     # x = ""
     # region = indices[0]
@@ -328,7 +328,7 @@ def format_seqkit_subseq(indices, subregion_type=None):
     return x
 
 
-def format_tab(indices, subregion_type=None):
+def format_tab(spec, indices, subregion_type=None):
     x = ""
     for idx, region in enumerate(indices):
         rg_strand = region.pop("strand")  # noqa
@@ -339,7 +339,7 @@ def format_tab(indices, subregion_type=None):
     return x[:-1]
 
 
-def format_starsolo(indices, subregion_type=None):
+def format_starsolo(spec, indices, subregion_type=None):
     bcs = []
     umi = []
     cdna = []
@@ -359,7 +359,7 @@ def format_starsolo(indices, subregion_type=None):
     return x
 
 
-def format_simpleaf(indices, subregion_type=None):
+def format_simpleaf(spec, indices, subregion_type=None):
     x = ""
     xl = []
     for idx, region in enumerate(indices):
@@ -379,7 +379,7 @@ def format_simpleaf(indices, subregion_type=None):
     return "".join(xl)
 
 
-def format_zumis(indices, subregion_type=None):
+def format_zumis(spec, indices, subregion_type=None):
     xl = []
     for idx, region in enumerate(indices):
         rg_strand = region.pop("strand")  # noqa
@@ -408,8 +408,8 @@ def stable_deduplicate_fqs(fqs):
     return deduplicated_fqs
 
 
-def format_chromap(indices, subregion_type=None):
     bc_fqs = []
+def format_chromap(spec, indices, subregion_type=None):
     bc_str = []
     gdna_fqs = []
     gdna_str = []
@@ -477,7 +477,7 @@ def filter_groupby_region_type(g, keep=["umi", "barcode", "cdna"]):
     return g
 
 
-def format_relative(indices, subregion_type=None):
+def format_relative(spec, indices, subregion_type=None):
     x = ""
     d = []
     for idx, region in enumerate(indices):
@@ -601,7 +601,7 @@ def format_splitcode_row(obj, rgncdiffs, idx=0, rev=False, complement=False):
     return {"region_type": obj.region_type, "fmt": e}
 
 
-def format_splitcode(indices, subregion_type=None):
+def format_splitcode(spec, indices, subregion_type=None):
     # extraction based on fixed sequences
     # extraction based on onlist sequences
     # umi - bc3 - link2 - bc2 - link1 - bc1 - read

--- a/tests/data/IGVFFI5228SMZU.yaml
+++ b/tests/data/IGVFFI5228SMZU.yaml
@@ -1,0 +1,217 @@
+!Assay
+seqspec_version: 0.3.0
+assay_id: Evercode-WT-v2-single-index
+name: Parse Evercode WT v2 using single illumina multiplex index
+doi: https://www.protocols.io/view/evercode-wt-mega-v2-2-1-8epv5xxrng1b/v1?step=21
+date: 08 November 2023
+description: split-pool ligation-based transcriptome sequencing
+modalities:
+- rna
+lib_struct: https://igvf.github.io/seqspec/
+library_protocol: single-nucleus RNA sequencing assay (OBI:0003109)
+library_kit: Evercode WT v2.0.1 single index
+sequence_protocol: Illumina NextSeq 2000 (EFO:0010963)
+sequence_kit: NextSeq 1000/2000 P3 Reagent Kit
+sequence_spec:
+- !Read
+  read_id: IGVFFI0800JAPD
+  name: Read 1 fastq for IGVFFI0800JAPD
+  modality: rna
+  primer_id: truseq_read1
+  min_len: 140
+  max_len: 140
+  strand: pos
+  files:
+  - !File
+    file_id: IGVFFI0800JAPD
+    filename: IGVFFI0800JAPD.fastq.gz
+    filetype: fastq
+    filesize: 11645547818
+    url: https://api.data.igvf.org/sequence-files/IGVFFI0800JAPD/@@download/IGVFFI0800JAPD.fastq.gz
+    urltype: https
+    md5: 243fb7c21baeedd32453c2f6c395eb9c
+- !Read
+  read_id: IGVFFI5241MPKQ
+  name: Read 2 fastq for IGVFFI5241MPKQ
+  modality: rna
+  primer_id: truseq_read2
+  min_len: 86
+  max_len: 86
+  strand: neg
+  files:
+  - !File
+    file_id: IGVFFI5241MPKQ
+    filename: IGVFFI5241MPKQ.fastq.gz
+    filetype: fastq
+    filesize: 6292907166
+    url: https://api.data.igvf.org/sequence-files/IGVFFI5241MPKQ/@@download/IGVFFI5241MPKQ.fastq.gz
+    urltype: https
+    md5: d9d9e5e4d4cfa4e8f954575dfb935a8d
+library_spec:
+- !Region
+  region_id: rna
+  region_type: named
+  name: rna
+  sequence_type: joined
+  sequence: AATGATACGGCGACCACCGAGATCTACACTCTTTCCCTACACGACGCTCTTCCGATCTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXNNNNNNNNATCCACGTGCTTGAGACTGTGGNNNNNNNNGTGGCCGATGTTTCGCATCGGCGTACGACTNNNNNNNNXXXXXXXXXXGTGACTGGAGTTCAGACGTGTGCTCTTCCGATCTXXXXXXXXATCTCGTATGCCGTCTTCTGCTTG
+  min_len: 350
+  max_len: 350
+  onlist: null
+  parent_id: null
+  regions:
+  - !Region
+    region_id: illumina_p5
+    region_type: illumina_p5
+    name: Illumina P5
+    sequence_type: fixed
+    sequence: AATGATACGGCGACCACCGAGATCTACAC
+    min_len: 29
+    max_len: 29
+    onlist: null
+    regions: null
+    parent_id: rna
+  - !Region
+    region_id: truseq_read1
+    region_type: truseq_read1
+    name: Truseq Single Index Read 1
+    sequence_type: fixed
+    sequence: TCTTTCCCTACACGACGCTCTTCCGATCT
+    min_len: 29
+    max_len: 29
+    onlist: null
+    regions: null
+    parent_id: rna
+  - !Region
+    region_id: IGVFFI0800JAPD
+    region_type: cdna
+    name: Read 1 cDNA sequence
+    sequence_type: random
+    sequence: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+    min_len: 140
+    max_len: 140
+    onlist: null
+    regions: null
+    parent_id: rna
+  - !Region
+    region_id: barcode-1
+    region_type: barcode
+    name: barcode-1
+    sequence_type: onlist
+    sequence: NNNNNNNN
+    min_len: 8
+    max_len: 8
+    onlist: !Onlist
+      file_id: IGVFFI0924TKJO
+      filename: IGVFFI0924TKJO.tsv.gz
+      filetype: tsv
+      filesize: 339
+      location: remote
+      url: https://api.data.igvf.org/tabular-files/IGVFFI0924TKJO/@@download/IGVFFI0924TKJO.tsv.gz
+      urltype: https
+      md5: 6d5016e63f121b6a64fb3907dd83f358
+    regions: null
+    parent_id: rna
+  - !Region
+    region_id: linker-1
+    region_type: linker
+    name: linker-1
+    sequence_type: fixed
+    sequence: ATCCACGTGCTTGAGACTGTGG
+    min_len: 22
+    max_len: 22
+    onlist: null
+    regions: null
+    parent_id: rna
+  - !Region
+    region_id: barcode-2
+    region_type: barcode
+    name: barcode-2
+    sequence_type: onlist
+    sequence: NNNNNNNN
+    min_len: 8
+    max_len: 8
+    onlist: !Onlist
+      file_id: IGVFFI1138MCVX
+      filename: IGVFFI1138MCVX.tsv.gz
+      filetype: tsv
+      filesize: 341
+      location: remote
+      url: https://api.data.igvf.org/tabular-files/IGVFFI1138MCVX/@@download/IGVFFI1138MCVX.tsv.gz
+      urltype: https
+      md5: 1452e8ef104e6edf686fab8956172072
+    regions: null
+    parent_id: rna
+  - !Region
+    region_id: linker-2
+    region_type: linker
+    name: linker-2
+    sequence_type: fixed
+    sequence: GTGGCCGATGTTTCGCATCGGCGTACGACT
+    min_len: 30
+    max_len: 30
+    onlist: null
+    regions: null
+    parent_id: rna
+  - !Region
+    region_id: barcode-3
+    region_type: barcode
+    name: barcode-3
+    sequence_type: onlist
+    sequence: NNNNNNNN
+    min_len: 8
+    max_len: 8
+    onlist: !Onlist
+      file_id: IGVFFI1138MCVX
+      filename: IGVFFI1138MCVX.tsv.gz
+      filetype: tsv
+      filesize: 341
+      location: remote
+      url: https://api.data.igvf.org/tabular-files/IGVFFI1138MCVX/@@download/IGVFFI1138MCVX.tsv.gz
+      urltype: https
+      md5: 1452e8ef104e6edf686fab8956172072
+    regions: null
+    parent_id: rna
+  - !Region
+    region_id: umi
+    region_type: umi
+    name: umi
+    sequence_type: random
+    sequence: XXXXXXXXXX
+    min_len: 10
+    max_len: 10
+    onlist: null
+    regions: null
+    parent_id: rna
+  - !Region
+    region_id: truseq_read2
+    region_type: truseq_read2
+    name: Truseq Read 2
+    sequence_type: fixed
+    sequence: GTGACTGGAGTTCAGACGTGTGCTCTTCCGATCT
+    min_len: 34
+    max_len: 34
+    onlist: null
+    regions: null
+    parent_id: rna
+  - !Region
+    region_id: index7
+    region_type: index7
+    name: Illumina barcode BC4
+    sequence_type: random
+    sequence: XXXXXXXX
+    min_len: 8
+    max_len: 8
+    onlist: null
+    regions: null
+    parent_id: rna
+  - !Region
+    region_id: illumina_p7
+    region_type: illumina_p7
+    name: Illumina P7
+    sequence_type: fixed
+    sequence: ATCTCGTATGCCGTCTTCTGCTTG
+    min_len: 24
+    max_len: 24
+    onlist: null
+    regions: null
+    parent_id: rna

--- a/tests/data/IGVFFI5228SMZU_fastq_gz.yaml
+++ b/tests/data/IGVFFI5228SMZU_fastq_gz.yaml
@@ -1,0 +1,217 @@
+!Assay
+seqspec_version: 0.3.0
+assay_id: Evercode-WT-v2-single-index
+name: Parse Evercode WT v2 using single illumina multiplex index
+doi: https://www.protocols.io/view/evercode-wt-mega-v2-2-1-8epv5xxrng1b/v1?step=21
+date: 08 November 2023
+description: split-pool ligation-based transcriptome sequencing
+modalities:
+- rna
+lib_struct: https://igvf.github.io/seqspec/
+library_protocol: single-nucleus RNA sequencing assay (OBI:0003109)
+library_kit: Evercode WT v2.0.1 single index
+sequence_protocol: Illumina NextSeq 2000 (EFO:0010963)
+sequence_kit: NextSeq 1000/2000 P3 Reagent Kit
+sequence_spec:
+- !Read
+  read_id: IGVFFI0800JAPD.fastq.gz
+  name: Read 1 fastq for IGVFFI0800JAPD
+  modality: rna
+  primer_id: truseq_read1
+  min_len: 140
+  max_len: 140
+  strand: pos
+  files:
+  - !File
+    file_id: IGVFFI0800JAPD
+    filename: IGVFFI0800JAPD.fastq.gz
+    filetype: fastq
+    filesize: 11645547818
+    url: https://api.data.igvf.org/sequence-files/IGVFFI0800JAPD/@@download/IGVFFI0800JAPD.fastq.gz
+    urltype: https
+    md5: 243fb7c21baeedd32453c2f6c395eb9c
+- !Read
+  read_id: IGVFFI5241MPKQ.fastq.gz
+  name: Read 2 fastq for IGVFFI5241MPKQ
+  modality: rna
+  primer_id: truseq_read2
+  min_len: 86
+  max_len: 86
+  strand: neg
+  files:
+  - !File
+    file_id: IGVFFI5241MPKQ
+    filename: IGVFFI5241MPKQ.fastq.gz
+    filetype: fastq
+    filesize: 6292907166
+    url: https://api.data.igvf.org/sequence-files/IGVFFI5241MPKQ/@@download/IGVFFI5241MPKQ.fastq.gz
+    urltype: https
+    md5: d9d9e5e4d4cfa4e8f954575dfb935a8d
+library_spec:
+- !Region
+  region_id: rna
+  region_type: named
+  name: rna
+  sequence_type: joined
+  sequence: AATGATACGGCGACCACCGAGATCTACACTCTTTCCCTACACGACGCTCTTCCGATCTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXNNNNNNNNATCCACGTGCTTGAGACTGTGGNNNNNNNNGTGGCCGATGTTTCGCATCGGCGTACGACTNNNNNNNNXXXXXXXXXXGTGACTGGAGTTCAGACGTGTGCTCTTCCGATCTXXXXXXXXATCTCGTATGCCGTCTTCTGCTTG
+  min_len: 350
+  max_len: 350
+  onlist: null
+  parent_id: null
+  regions:
+  - !Region
+    region_id: illumina_p5
+    region_type: illumina_p5
+    name: Illumina P5
+    sequence_type: fixed
+    sequence: AATGATACGGCGACCACCGAGATCTACAC
+    min_len: 29
+    max_len: 29
+    onlist: null
+    regions: null
+    parent_id: rna
+  - !Region
+    region_id: truseq_read1
+    region_type: truseq_read1
+    name: Truseq Single Index Read 1
+    sequence_type: fixed
+    sequence: TCTTTCCCTACACGACGCTCTTCCGATCT
+    min_len: 29
+    max_len: 29
+    onlist: null
+    regions: null
+    parent_id: rna
+  - !Region
+    region_id: IGVFFI0800JAPD
+    region_type: cdna
+    name: Read 1 cDNA sequence
+    sequence_type: random
+    sequence: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+    min_len: 140
+    max_len: 140
+    onlist: null
+    regions: null
+    parent_id: rna
+  - !Region
+    region_id: barcode-1
+    region_type: barcode
+    name: barcode-1
+    sequence_type: onlist
+    sequence: NNNNNNNN
+    min_len: 8
+    max_len: 8
+    onlist: !Onlist
+      file_id: IGVFFI0924TKJO
+      filename: IGVFFI0924TKJO.tsv.gz
+      filetype: tsv
+      filesize: 339
+      location: remote
+      url: https://api.data.igvf.org/tabular-files/IGVFFI0924TKJO/@@download/IGVFFI0924TKJO.tsv.gz
+      urltype: https
+      md5: 6d5016e63f121b6a64fb3907dd83f358
+    regions: null
+    parent_id: rna
+  - !Region
+    region_id: linker-1
+    region_type: linker
+    name: linker-1
+    sequence_type: fixed
+    sequence: ATCCACGTGCTTGAGACTGTGG
+    min_len: 22
+    max_len: 22
+    onlist: null
+    regions: null
+    parent_id: rna
+  - !Region
+    region_id: barcode-2
+    region_type: barcode
+    name: barcode-2
+    sequence_type: onlist
+    sequence: NNNNNNNN
+    min_len: 8
+    max_len: 8
+    onlist: !Onlist
+      file_id: IGVFFI1138MCVX
+      filename: IGVFFI1138MCVX.tsv.gz
+      filetype: tsv
+      filesize: 341
+      location: remote
+      url: https://api.data.igvf.org/tabular-files/IGVFFI1138MCVX/@@download/IGVFFI1138MCVX.tsv.gz
+      urltype: https
+      md5: 1452e8ef104e6edf686fab8956172072
+    regions: null
+    parent_id: rna
+  - !Region
+    region_id: linker-2
+    region_type: linker
+    name: linker-2
+    sequence_type: fixed
+    sequence: GTGGCCGATGTTTCGCATCGGCGTACGACT
+    min_len: 30
+    max_len: 30
+    onlist: null
+    regions: null
+    parent_id: rna
+  - !Region
+    region_id: barcode-3
+    region_type: barcode
+    name: barcode-3
+    sequence_type: onlist
+    sequence: NNNNNNNN
+    min_len: 8
+    max_len: 8
+    onlist: !Onlist
+      file_id: IGVFFI1138MCVX
+      filename: IGVFFI1138MCVX.tsv.gz
+      filetype: tsv
+      filesize: 341
+      location: remote
+      url: https://api.data.igvf.org/tabular-files/IGVFFI1138MCVX/@@download/IGVFFI1138MCVX.tsv.gz
+      urltype: https
+      md5: 1452e8ef104e6edf686fab8956172072
+    regions: null
+    parent_id: rna
+  - !Region
+    region_id: umi
+    region_type: umi
+    name: umi
+    sequence_type: random
+    sequence: XXXXXXXXXX
+    min_len: 10
+    max_len: 10
+    onlist: null
+    regions: null
+    parent_id: rna
+  - !Region
+    region_id: truseq_read2
+    region_type: truseq_read2
+    name: Truseq Read 2
+    sequence_type: fixed
+    sequence: GTGACTGGAGTTCAGACGTGTGCTCTTCCGATCT
+    min_len: 34
+    max_len: 34
+    onlist: null
+    regions: null
+    parent_id: rna
+  - !Region
+    region_id: index7
+    region_type: index7
+    name: Illumina barcode BC4
+    sequence_type: random
+    sequence: XXXXXXXX
+    min_len: 8
+    max_len: 8
+    onlist: null
+    regions: null
+    parent_id: rna
+  - !Region
+    region_id: illumina_p7
+    region_type: illumina_p7
+    name: Illumina P7
+    sequence_type: fixed
+    sequence: ATCTCGTATGCCGTCTTCTGCTTG
+    min_len: 24
+    max_len: 24
+    onlist: null
+    regions: null
+    parent_id: rna

--- a/tests/data/IGVFFI9241RRZV.yaml
+++ b/tests/data/IGVFFI9241RRZV.yaml
@@ -1,5 +1,5 @@
 !Assay
-seqspec_version: 0.2.0
+seqspec_version: 0.3.0
 assay_id: SHARE-Seq
 name: SHARE-Seq
 doi: https://doi.org/10.1016/j.cell.2020.09.056
@@ -22,6 +22,15 @@ sequence_spec:
   min_len: 150
   max_len: 150
   strand: pos
+  files:
+  - !File
+    file_id: IGVFFI4653IBZO
+    filename: IGVFFI4653IBZO.fastq.gz
+    filetype: fastq
+    filesize: 1372617129
+    url: https://api.data.igvf.org/sequence-files/IGVFFI4653IBZO/@@download/IGVFFI4653IBZO.fastq.gz
+    urltype: https
+    md5: 45969cc58c3e685c74815571d27a2b50
 - !Read
   read_id: IGVFFI3278EOPV
   name: Read 2
@@ -30,6 +39,15 @@ sequence_spec:
   min_len: 149
   max_len: 149
   strand: pos
+  files:
+  - !File
+    file_id: IGVFFI3278EOPV
+    filename: IGVFFI3278EOPV.fastq.gz
+    filetype: fastq
+    filesize: 1140067655
+    url: https://api.data.igvf.org/sequence-files/IGVFFI3278EOPV/@@download/IGVFFI3278EOPV.fastq.gz
+    urltype: https
+    md5: 6d034ed99fb3319a6befe9c5cb550abb
 library_spec:
 - !Region
   region_id: atac
@@ -116,8 +134,13 @@ library_spec:
       min_len: 8
       max_len: 8
       onlist: !Onlist
-        filename: https://api.data.igvf.org/tabular-files/IGVFFI0400MBIM/@@download/IGVFFI0400MBIM.txt.gz
-        md5: 73c3fc43ddcf2c84e4731e33b1e1b5f5
+        file_id: IGVFFI0400MBIM
+        filename: IGVFFI0400MBIM.tsv.gz
+        filetype: tsv
+        filesize: 668
+        url: https://api.data.igvf.org/tabular-files/IGVFFI0400MBIM/@@download/IGVFFI0400MBIM.tsv.gz
+        urltype: https
+        md5: fd324502471275874b08f2a0e9255082
         location: remote
       regions: null
       parent_id: atac-raw-cell-barcode
@@ -141,8 +164,13 @@ library_spec:
       min_len: 8
       max_len: 8
       onlist: !Onlist
-        filename: https://api.data.igvf.org/tabular-files/IGVFFI0400MBIM/@@download/IGVFFI0400MBIM.txt.gz
-        md5: 73c3fc43ddcf2c84e4731e33b1e1b5f5
+        file_id: IGVFFI0400MBIM
+        filename: IGVFFI0400MBIM.tsv.gz
+        filetype: tsv
+        filesize: 668
+        url: https://api.data.igvf.org/tabular-files/IGVFFI0400MBIM/@@download/IGVFFI0400MBIM.tsv.gz
+        urltype: https
+        md5: fd324502471275874b08f2a0e9255082
         location: remote
       regions: null
       parent_id: atac-raw-cell-barcode
@@ -166,8 +194,13 @@ library_spec:
       min_len: 8
       max_len: 8
       onlist: !Onlist
-        filename: https://api.data.igvf.org/tabular-files/IGVFFI0400MBIM/@@download/IGVFFI0400MBIM.txt.gz
-        md5: 73c3fc43ddcf2c84e4731e33b1e1b5f5
+        file_id: IGVFFI0400MBIM
+        filename: IGVFFI0400MBIM.tsv.gz
+        filetype: tsv
+        filesize: 668
+        url: https://api.data.igvf.org/tabular-files/IGVFFI0400MBIM/@@download/IGVFFI0400MBIM.tsv.gz
+        urltype: https
+        md5: fd324502471275874b08f2a0e9255082
         location: remote
       regions: null
       parent_id: atac-raw-cell-barcode

--- a/tests/data/IGVFFI9241RRZV.yaml
+++ b/tests/data/IGVFFI9241RRZV.yaml
@@ -1,0 +1,174 @@
+!Assay
+seqspec_version: 0.2.0
+assay_id: SHARE-Seq
+name: SHARE-Seq
+doi: https://doi.org/10.1016/j.cell.2020.09.056
+date: 23 October 2020
+description: Simultaneous high-throughput atac and rna expression in the same single
+  cell
+lib_struct: https://teichlab.github.io/scg_lib_structs/methods_html/SHARE-seq.html
+modalities:
+- atac
+library_protocol: Any
+library_kit: Illumina Truseq Dual Index
+sequence_protocol: Illumina NovaSeq 6000
+sequence_kit: NovaSeq 6000 v1.5
+sequence_spec:
+- !Read
+  read_id: IGVFFI4653IBZO
+  name: Read 1
+  modality: atac
+  primer_id: atac-truseq_read1
+  min_len: 150
+  max_len: 150
+  strand: pos
+- !Read
+  read_id: IGVFFI3278EOPV
+  name: Read 2
+  modality: atac
+  primer_id: atac-truseq_read2
+  min_len: 149
+  max_len: 149
+  strand: pos
+library_spec:
+- !Region
+  region_id: atac
+  region_type: atac
+  name: atac
+  sequence_type: joined
+  sequence: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXTCGGACGATCATGGGNNNNNNNNCAAGTATGCAGCGCGCTCAAGCACGTGGATNNNNNNNNAGTCGTACGCCGATGCGAAACATCGGCCACNNNNNNNN
+  min_len: 299
+  max_len: 299
+  onlist: null
+  regions:
+  - !Region
+    region_id: atac-truseq_read1
+    region_type: truseq_read1
+    name: Truseq Read 1
+    sequence_type: fixed
+    sequence: null
+    min_len: 0
+    max_len: 0
+    onlist: null
+    regions: null
+    parent_id: atac
+  - !Region
+    region_id: atac-gdna-1
+    region_type: gdna
+    name: Genomic DNA
+    sequence_type: random
+    sequence: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+    min_len: 150
+    max_len: 150
+    onlist: null
+    regions: null
+    parent_id: atac
+  - !Region
+    region_id: atac-truseq_read2
+    region_type: truseq_read2
+    name: Truseq Read 2
+    sequence_type: fixed
+    sequence: null
+    min_len: 0
+    max_len: 0
+    onlist: null
+    regions: null
+    parent_id: atac
+  - !Region
+    region_id: atac-gdna-2
+    region_type: gdna
+    name: Genomic DNA
+    sequence_type: random
+    sequence: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+    min_len: 50
+    max_len: 50
+    onlist: null
+    regions: null
+    parent_id: atac
+  - !Region
+    region_id: atac-raw-cell-barcode
+    region_type: named
+    name: atac Raw Cell Barcode
+    sequence_type: joined
+    sequence: TCGGACGATCATGGGNNNNNNNNCAAGTATGCAGCGCGCTCAAGCACGTGGATNNNNNNNNAGTCGTACGCCGATGCGAAACATCGGCCACNNNNNNNN
+    min_len: 99
+    max_len: 99
+    onlist: null
+    parent_id: atac
+    regions:
+    - !Region
+      region_id: atac-linker1
+      region_type: linker
+      name: atac linker1
+      sequence_type: fixed
+      sequence: TCGGACGATCATGGG
+      min_len: 15
+      max_len: 15
+      onlist: null
+      regions: null
+      parent_id: atac-raw-cell-barcode
+    - !Region
+      region_id: atac-cell-barcode1
+      region_type: barcode
+      name: atac Cell Barcode 1
+      sequence_type: onlist
+      sequence: NNNNNNNN
+      min_len: 8
+      max_len: 8
+      onlist: !Onlist
+        filename: https://api.data.igvf.org/tabular-files/IGVFFI0400MBIM/@@download/IGVFFI0400MBIM.txt.gz
+        md5: 73c3fc43ddcf2c84e4731e33b1e1b5f5
+        location: remote
+      regions: null
+      parent_id: atac-raw-cell-barcode
+    - !Region
+      region_id: atac-linker2
+      region_type: linker
+      name: linker2
+      sequence_type: fixed
+      sequence: CAAGTATGCAGCGCGCTCAAGCACGTGGAT
+      min_len: 30
+      max_len: 30
+      onlist: null
+      regions: null
+      parent_id: atac-raw-cell-barcode
+    - !Region
+      region_id: atac-cell-barcode2
+      region_type: barcode
+      name: atac Cell Barcode 2
+      sequence_type: onlist
+      sequence: NNNNNNNN
+      min_len: 8
+      max_len: 8
+      onlist: !Onlist
+        filename: https://api.data.igvf.org/tabular-files/IGVFFI0400MBIM/@@download/IGVFFI0400MBIM.txt.gz
+        md5: 73c3fc43ddcf2c84e4731e33b1e1b5f5
+        location: remote
+      regions: null
+      parent_id: atac-raw-cell-barcode
+    - !Region
+      region_id: atac-linker3
+      region_type: linker
+      name: linker3
+      sequence_type: fixed
+      sequence: AGTCGTACGCCGATGCGAAACATCGGCCAC
+      min_len: 30
+      max_len: 30
+      onlist: null
+      regions: null
+      parent_id: atac-raw-cell-barcode
+    - !Region
+      region_id: atac-cell-barcode3
+      region_type: barcode
+      name: atac Cell Barcode 3
+      sequence_type: onlist
+      sequence: NNNNNNNN
+      min_len: 8
+      max_len: 8
+      onlist: !Onlist
+        filename: https://api.data.igvf.org/tabular-files/IGVFFI0400MBIM/@@download/IGVFFI0400MBIM.txt.gz
+        md5: 73c3fc43ddcf2c84e4731e33b1e1b5f5
+        location: remote
+      regions: null
+      parent_id: atac-raw-cell-barcode
+  parent_id: null

--- a/tests/data/IGVFFI9241RRZV_fastq_gz.yaml
+++ b/tests/data/IGVFFI9241RRZV_fastq_gz.yaml
@@ -1,5 +1,5 @@
 !Assay
-seqspec_version: 0.2.0
+seqspec_version: 0.3.0
 assay_id: SHARE-Seq
 name: SHARE-Seq
 doi: https://doi.org/10.1016/j.cell.2020.09.056
@@ -22,6 +22,15 @@ sequence_spec:
   min_len: 150
   max_len: 150
   strand: pos
+  files:
+  - !File
+    file_id: IGVFFI4653IBZO.fastq.gz
+    filename: IGVFFI4653IBZO.fastq.gz
+    filetype: fastq
+    filesize: 1372617129
+    url: https://api.data.igvf.org/sequence-files/IGVFFI4653IBZO/@@download/IGVFFI4653IBZO.fastq.gz
+    urltype: https
+    md5: 45969cc58c3e685c74815571d27a2b50    
 - !Read
   read_id: IGVFFI3278EOPV.fastq.gz
   name: Read 2
@@ -30,6 +39,15 @@ sequence_spec:
   min_len: 149
   max_len: 149
   strand: pos
+  files:
+  - !File
+    file_id: IGVFFI3278EOPV.fastq.gz
+    filename: IGVFFI3278EOPV.fastq.gz
+    filetype: fastq
+    filesize: 1140067655
+    url: https://api.data.igvf.org/sequence-files/IGVFFI3278EOPV/@@download/IGVFFI3278EOPV.fastq.gz
+    urltype: https
+    md5: 6d034ed99fb3319a6befe9c5cb550abb
 library_spec:
 - !Region
   region_id: atac
@@ -116,8 +134,13 @@ library_spec:
       min_len: 8
       max_len: 8
       onlist: !Onlist
-        filename: https://api.data.igvf.org/tabular-files/IGVFFI0400MBIM/@@download/IGVFFI0400MBIM.txt.gz
-        md5: 73c3fc43ddcf2c84e4731e33b1e1b5f5
+        file_id: IGVFFI0400MBIM.tsv.gz
+        filename: IGVFFI0400MBIM.tsv.gz
+        filetype: tsv
+        filesize: 668
+        url: https://api.data.igvf.org/tabular-files/IGVFFI0400MBIM/@@download/IGVFFI0400MBIM.tsv.gz
+        urltype: https
+        md5: fd324502471275874b08f2a0e9255082
         location: remote
       regions: null
       parent_id: atac-raw-cell-barcode
@@ -141,8 +164,13 @@ library_spec:
       min_len: 8
       max_len: 8
       onlist: !Onlist
-        filename: https://api.data.igvf.org/tabular-files/IGVFFI0400MBIM/@@download/IGVFFI0400MBIM.txt.gz
-        md5: 73c3fc43ddcf2c84e4731e33b1e1b5f5
+        file_id: IGVFFI0400MBIM.tsv.gz
+        filename: IGVFFI0400MBIM.tsv.gz
+        filetype: tsv
+        filesize: 668
+        url: https://api.data.igvf.org/tabular-files/IGVFFI0400MBIM/@@download/IGVFFI0400MBIM.tsv.gz
+        urltype: https
+        md5: fd324502471275874b08f2a0e9255082
         location: remote
       regions: null
       parent_id: atac-raw-cell-barcode
@@ -166,8 +194,13 @@ library_spec:
       min_len: 8
       max_len: 8
       onlist: !Onlist
-        filename: https://api.data.igvf.org/tabular-files/IGVFFI0400MBIM/@@download/IGVFFI0400MBIM.txt.gz
-        md5: 73c3fc43ddcf2c84e4731e33b1e1b5f5
+        file_id: IGVFFI0400MBIM.tsv.gz
+        filename: IGVFFI0400MBIM.tsv.gz
+        filetype: tsv
+        filesize: 668
+        url: https://api.data.igvf.org/tabular-files/IGVFFI0400MBIM/@@download/IGVFFI0400MBIM.tsv.gz
+        urltype: https
+        md5: fd324502471275874b08f2a0e9255082
         location: remote
       regions: null
       parent_id: atac-raw-cell-barcode

--- a/tests/data/IGVFFI9241RRZV_fastq_gz.yaml
+++ b/tests/data/IGVFFI9241RRZV_fastq_gz.yaml
@@ -1,0 +1,174 @@
+!Assay
+seqspec_version: 0.2.0
+assay_id: SHARE-Seq
+name: SHARE-Seq
+doi: https://doi.org/10.1016/j.cell.2020.09.056
+date: 23 October 2020
+description: Simultaneous high-throughput atac and rna expression in the same single
+  cell
+lib_struct: https://teichlab.github.io/scg_lib_structs/methods_html/SHARE-seq.html
+modalities:
+- atac
+library_protocol: Any
+library_kit: Illumina Truseq Dual Index
+sequence_protocol: Illumina NovaSeq 6000
+sequence_kit: NovaSeq 6000 v1.5
+sequence_spec:
+- !Read
+  read_id: IGVFFI4653IBZO.fastq.gz
+  name: Read 1
+  modality: atac
+  primer_id: atac-truseq_read1
+  min_len: 150
+  max_len: 150
+  strand: pos
+- !Read
+  read_id: IGVFFI3278EOPV.fastq.gz
+  name: Read 2
+  modality: atac
+  primer_id: atac-truseq_read2
+  min_len: 149
+  max_len: 149
+  strand: pos
+library_spec:
+- !Region
+  region_id: atac
+  region_type: atac
+  name: atac
+  sequence_type: joined
+  sequence: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXTCGGACGATCATGGGNNNNNNNNCAAGTATGCAGCGCGCTCAAGCACGTGGATNNNNNNNNAGTCGTACGCCGATGCGAAACATCGGCCACNNNNNNNN
+  min_len: 299
+  max_len: 299
+  onlist: null
+  regions:
+  - !Region
+    region_id: atac-truseq_read1
+    region_type: truseq_read1
+    name: Truseq Read 1
+    sequence_type: fixed
+    sequence: null
+    min_len: 0
+    max_len: 0
+    onlist: null
+    regions: null
+    parent_id: atac
+  - !Region
+    region_id: atac-gdna-1
+    region_type: gdna
+    name: Genomic DNA
+    sequence_type: random
+    sequence: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+    min_len: 150
+    max_len: 150
+    onlist: null
+    regions: null
+    parent_id: atac
+  - !Region
+    region_id: atac-truseq_read2
+    region_type: truseq_read2
+    name: Truseq Read 2
+    sequence_type: fixed
+    sequence: null
+    min_len: 0
+    max_len: 0
+    onlist: null
+    regions: null
+    parent_id: atac
+  - !Region
+    region_id: atac-gdna-2
+    region_type: gdna
+    name: Genomic DNA
+    sequence_type: random
+    sequence: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+    min_len: 50
+    max_len: 50
+    onlist: null
+    regions: null
+    parent_id: atac
+  - !Region
+    region_id: atac-raw-cell-barcode
+    region_type: named
+    name: atac Raw Cell Barcode
+    sequence_type: joined
+    sequence: TCGGACGATCATGGGNNNNNNNNCAAGTATGCAGCGCGCTCAAGCACGTGGATNNNNNNNNAGTCGTACGCCGATGCGAAACATCGGCCACNNNNNNNN
+    min_len: 99
+    max_len: 99
+    onlist: null
+    parent_id: atac
+    regions:
+    - !Region
+      region_id: atac-linker1
+      region_type: linker
+      name: atac linker1
+      sequence_type: fixed
+      sequence: TCGGACGATCATGGG
+      min_len: 15
+      max_len: 15
+      onlist: null
+      regions: null
+      parent_id: atac-raw-cell-barcode
+    - !Region
+      region_id: atac-cell-barcode1
+      region_type: barcode
+      name: atac Cell Barcode 1
+      sequence_type: onlist
+      sequence: NNNNNNNN
+      min_len: 8
+      max_len: 8
+      onlist: !Onlist
+        filename: https://api.data.igvf.org/tabular-files/IGVFFI0400MBIM/@@download/IGVFFI0400MBIM.txt.gz
+        md5: 73c3fc43ddcf2c84e4731e33b1e1b5f5
+        location: remote
+      regions: null
+      parent_id: atac-raw-cell-barcode
+    - !Region
+      region_id: atac-linker2
+      region_type: linker
+      name: linker2
+      sequence_type: fixed
+      sequence: CAAGTATGCAGCGCGCTCAAGCACGTGGAT
+      min_len: 30
+      max_len: 30
+      onlist: null
+      regions: null
+      parent_id: atac-raw-cell-barcode
+    - !Region
+      region_id: atac-cell-barcode2
+      region_type: barcode
+      name: atac Cell Barcode 2
+      sequence_type: onlist
+      sequence: NNNNNNNN
+      min_len: 8
+      max_len: 8
+      onlist: !Onlist
+        filename: https://api.data.igvf.org/tabular-files/IGVFFI0400MBIM/@@download/IGVFFI0400MBIM.txt.gz
+        md5: 73c3fc43ddcf2c84e4731e33b1e1b5f5
+        location: remote
+      regions: null
+      parent_id: atac-raw-cell-barcode
+    - !Region
+      region_id: atac-linker3
+      region_type: linker
+      name: linker3
+      sequence_type: fixed
+      sequence: AGTCGTACGCCGATGCGAAACATCGGCCAC
+      min_len: 30
+      max_len: 30
+      onlist: null
+      regions: null
+      parent_id: atac-raw-cell-barcode
+    - !Region
+      region_id: atac-cell-barcode3
+      region_type: barcode
+      name: atac Cell Barcode 3
+      sequence_type: onlist
+      sequence: NNNNNNNN
+      min_len: 8
+      max_len: 8
+      onlist: !Onlist
+        filename: https://api.data.igvf.org/tabular-files/IGVFFI0400MBIM/@@download/IGVFFI0400MBIM.txt.gz
+        md5: 73c3fc43ddcf2c84e4731e33b1e1b5f5
+        location: remote
+      regions: null
+      parent_id: atac-raw-cell-barcode
+  parent_id: null

--- a/tests/test_seqspec_index.py
+++ b/tests/test_seqspec_index.py
@@ -1,0 +1,101 @@
+from argparse import ArgumentParser
+from contextlib import contextmanager
+from importlib import resources
+from io import StringIO
+import os
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+from unittest.mock import patch
+
+from seqspec.seqspec_index import (
+    setup_index_args,
+    validate_index_args,
+)
+from .test_utils import example_spec, load_example_spec
+
+
+class TestSeqspecIndex(TestCase):
+    def test_index_kb_with_fastq_gz(self):
+        parser = ArgumentParser()
+        subparser = parser.add_subparsers(dest="command")
+        subparser = setup_index_args(subparser)
+        with resources.path("tests.data", "IGVFFI5228SMZU_fastq_gz.yaml") as spec_path:
+            args = parser.parse_args([
+                "index",
+                "-m",
+                "rna",
+                "-t",
+                "kb",
+                "-s",
+                "read",
+                "-i",
+                "IGVFFI0800JAPD.fastq.gz,IGVFFI5241MPKQ.fastq.gz",
+                str(spec_path)])
+
+        kb_tool = validate_index_args(parser, args)
+        self.assertEqual(kb_tool, "1,10,18,1,48,56,1,78,86:1,0,10:0,0,140")
+
+    def test_index_kb_without_fastq_gz(self):
+        parser = ArgumentParser()
+        subparser = parser.add_subparsers(dest="command")
+        subparser = setup_index_args(subparser)
+        with resources.path("tests.data", "IGVFFI5228SMZU.yaml") as spec_path:
+            args = parser.parse_args([
+                "index",
+                "-m",
+                "rna",
+                "-t",
+                "kb",
+                "-s",
+                "read",
+                "-i",
+                "IGVFFI0800JAPD,IGVFFI5241MPKQ",
+                str(spec_path)])
+
+        kb_tool = validate_index_args(parser, args)
+        self.assertEqual(kb_tool, "1,10,18,1,48,56,1,78,86:1,0,10:0,0,140")
+
+    def test_index_chromap_with_fastq_gz(self):
+        parser = ArgumentParser()
+        subparser = parser.add_subparsers(dest="command")
+        subparser = setup_index_args(subparser)
+        with resources.path("tests.data", "IGVFFI9241RRZV_fastq_gz.yaml") as spec_path:
+            args = parser.parse_args([
+                "index",
+                "-m",
+                "atac",
+                "-t",
+                "chromap",
+                "-s",
+                "read",
+                "-i",
+                "IGVFFI4653IBZO.fastq.gz,IGVFFI3278EOPV.fastq.gz",
+                str(spec_path)])
+
+        chromap_tool = validate_index_args(parser, args)
+        self.assertEqual(
+            chromap_tool,
+            "-1 IGVFFI4653IBZO.fastq.gz -2 IGVFFI3278EOPV.fastq.gz --barcode IGVFFI3278EOPV.fastq.gz --read-format bc:65:72,bc:103:110,bc:141:148,r1:0:149,r2:0:49")
+
+        
+    def test_index_chromap_without_fastq_gz(self):
+        parser = ArgumentParser()
+        subparser = parser.add_subparsers(dest="command")
+        subparser = setup_index_args(subparser)
+        with resources.path("tests.data", "IGVFFI9241RRZV.yaml") as spec_path:
+            args = parser.parse_args([
+                "index",
+                "-m",
+                "atac",
+                "-t",
+                "chromap",
+                "-s",
+                "read",
+                "-i",
+                "IGVFFI4653IBZO,IGVFFI3278EOPV",
+                str(spec_path)])
+
+        chromap_tool = validate_index_args(parser, args)
+        self.assertEqual(
+            chromap_tool,
+            "-1 IGVFFI4653IBZO.fastq.gz -2 IGVFFI3278EOPV.fastq.gz --barcode IGVFFI3278EOPV.fastq.gz --read-format bc:65:72,bc:103:110,bc:141:148,r1:0:149,r2:0:49")


### PR DESCRIPTION
Adds some tests to make test format_kallisto and format_chromap to make sure it returns expected output, and then implements returning the filenames in the format_chromap function instead of read_ids.

This might not be the most elegant solution, but it did work.

fixes https://github.com/pachterlab/seqspec/issues/64

Ideally this should be merged after the unit test fix pull request, but it's a separate pull request because it's logically different.